### PR TITLE
Extract the package from upstream deeper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN { \
 RUN set -x; \
 	curl -SL "$DOWNLOAD_URL" -o /tmp/lime.tar.gz; \
     echo "$DOWNLOAD_SHA256 /tmp/lime.tar.gz" | sha256sum -c -; \
-    tar xf /tmp/lime.tar.gz --strip-components=1 -C /var/www/html; \ 
+    tar xf /tmp/lime.tar.gz --strip-components=9 -C /var/www/html; \ 
     rm /tmp/lime.tar.gz; \
     chown -R www-data:www-data /var/www/html
 


### PR DESCRIPTION
Extract deeper since the web root is surprisingly now in `var/www/clients/client1/web57/private/frontend/tmp/limesurvey/`, which is a 9.