### PR TITLE
updated download link to latest; updated cybercert to reflect new url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.2-apache
 
-ENV DOWNLOAD_URL https://www.limesurvey.org/stable-release?download=2833:limesurvey413%20200213targz
-ENV DOWNLOAD_SHA256 6da8286378b439a1febd2b28722122c4b2edca2f3cae2127344da9397bb96b20
+ENV DOWNLOAD_URL https://www.limesurvey.org/stable-release?download=2838:limesurvey414%20200214targz
+ENV DOWNLOAD_SHA256 be5cf7b5812e56568dc016f27c127c27f3e3ea548afadefe66ba0b7aa5669732
 
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,7 +62,7 @@ EOPHP
 	# Install BaltimoreCyberTrustRoot.crt.pem
 	if [ ! -e BaltimoreCyberTrustRoot.crt.pem ]; then
 		echo "Downloading BaltimoreCyberTrustroot.crt.pem"
-		curl -o BaltimoreCyberTrustRoot.crt.pem -fsL "https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem"
+		curl -o BaltimoreCyberTrustRoot.crt.pem -fsL "https://dl.cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem"
     fi
 
     # see http://stackoverflow.com/a/2705678/433558


### PR DESCRIPTION
The digicert download url for the BaltimoreCyberTrustRoot.crt.pem certificate has changed. This branch also contains an update the 4.1.4 release of limesurvey. 