### PR TITLE
Let the build fail if the checksum of the zip does not match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN { \
 
 RUN set -x; \
     curl -SL "$DOWNLOAD_URL" -o /tmp/lime.zip; \
-    echo "$DOWNLOAD_SHA256 /tmp/lime.zip" | sha256sum -c -; \
+    echo "$DOWNLOAD_SHA256 /tmp/lime.zip" | sha256sum -c - || exit 1; \
     unzip /tmp/lime.zip -d /tmp; \
     mv /tmp/lime*/* /var/www/html/; \
     mv /tmp/lime*/.[a-zA-Z]* /var/www/html/; \


### PR DESCRIPTION
Currently a warning `sha256sum: WARNING: 1 computed checksum did NOT match` is issued in case the zip found at `DOWNLOAD_URL` does not match the checksum in `DOWNLOAD_SHA256`, but the build of the image does not fail, rendering the checksum comparison pretty useless.

This pull request lets the build of the docker image fail, in case the downloaded zip file does not match the checksum in the Dockerfile.