### PR TITLE
Added libldap package in order to fix ldaps (Missing Cert)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DOWNLOAD_URL https://download.limesurvey.org/latest-stable-release/limesurve
 ENV DOWNLOAD_SHA256 2b9364a6885484f35f878f06603262ad00ca5d3fe3a715f7a28174755efe16c3
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
 	&& docker-php-ext-install gd mysqli pdo pdo_mysql opcache zip iconv tidy \
     && docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ \


### PR DESCRIPTION
The limesurvey was unable to establish ldpas connection on port 636 using ldap plugin.
It was solved by installing the libldap-common package.
Otherwise there is a no trace why the connection is impossible to establish.