### PR TITLE
Allow SMTP configuration via environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV DOWNLOAD_SHA256 f63a3194a60a91240d244796cc9b9f6320fee7cc59622c74c3c427cd1e3a
 
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
-	&& docker-php-ext-install gd mysqli pdo pdo_mysql opcache zip iconv tidy \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
+    && docker-php-ext-install gd mysqli pdo pdo_mysql opcache zip iconv tidy \
     && docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \
@@ -21,13 +21,13 @@ RUN a2enmod rewrite
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=2'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=4000'; \
+        echo 'opcache.revalidate_freq=2'; \
+        echo 'opcache.fast_shutdown=1'; \
+        echo 'opcache.enable_cli=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN set -x; \
     curl -SL "$DOWNLOAD_URL" -o /tmp/lime.zip; \
@@ -50,15 +50,15 @@ RUN set -x; \
 
 #Set PHP defaults for Limesurvey (allow bigger uploads)
 RUN { \
-		echo 'memory_limit=256M'; \
-		echo 'upload_max_filesize=128M'; \
-		echo 'post_max_size=128M'; \
-		echo 'max_execution_time=120'; \
-		echo 'max_input_vars=10000'; \
-		echo 'date.timezone=UTC'; \
-		echo 'session.gc_maxlifetime=86400'; \
-		echo 'session.save_path="/var/lime/sessions"'; \
-	} > /usr/local/etc/php/conf.d/limesurvey.ini
+        echo 'memory_limit=256M'; \
+        echo 'upload_max_filesize=128M'; \
+        echo 'post_max_size=128M'; \
+        echo 'max_execution_time=120'; \
+        echo 'max_input_vars=10000'; \
+        echo 'date.timezone=UTC'; \
+        echo 'session.gc_maxlifetime=86400'; \
+        echo 'session.save_path="/var/lime/sessions"'; \
+    } > /usr/local/etc/php/conf.d/limesurvey.ini
 
 VOLUME ["/var/www/html/plugins"]
 VOLUME ["/var/www/html/upload"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,8 +5,8 @@ ENV DOWNLOAD_SHA256 LIME_SHA
 
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
-	&& docker-php-ext-install gd mysqli pdo pdo_mysql opcache zip iconv tidy \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
+    && docker-php-ext-install gd mysqli pdo pdo_mysql opcache zip iconv tidy \
     && docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \
@@ -21,13 +21,13 @@ RUN a2enmod rewrite
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=2'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=4000'; \
+        echo 'opcache.revalidate_freq=2'; \
+        echo 'opcache.fast_shutdown=1'; \
+        echo 'opcache.enable_cli=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN set -x; \
     curl -SL "$DOWNLOAD_URL" -o /tmp/lime.zip; \
@@ -50,15 +50,15 @@ RUN set -x; \
 
 #Set PHP defaults for Limesurvey (allow bigger uploads)
 RUN { \
-		echo 'memory_limit=256M'; \
-		echo 'upload_max_filesize=128M'; \
-		echo 'post_max_size=128M'; \
-		echo 'max_execution_time=120'; \
-		echo 'max_input_vars=10000'; \
-		echo 'date.timezone=UTC'; \
-		echo 'session.gc_maxlifetime=86400'; \
-		echo 'session.save_path="/var/lime/sessions"'; \
-	} > /usr/local/etc/php/conf.d/limesurvey.ini
+        echo 'memory_limit=256M'; \
+        echo 'upload_max_filesize=128M'; \
+        echo 'post_max_size=128M'; \
+        echo 'max_execution_time=120'; \
+        echo 'max_input_vars=10000'; \
+        echo 'date.timezone=UTC'; \
+        echo 'session.gc_maxlifetime=86400'; \
+        echo 'session.save_path="/var/lime/sessions"'; \
+    } > /usr/local/etc/php/conf.d/limesurvey.ini
 
 VOLUME ["/var/www/html/plugins"]
 VOLUME ["/var/www/html/upload"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ The following environment variables are also honored for configuring your Limesu
 -	`-e LIMESURVEY_ADMIN_PASSWORD=...` (defaults to "" - the password of the Limesurvey administrator)
 -	`-e LIMESURVEY_ADMIN_NAME=...` (defaults to "Lime Administrator" - The full name of the Limesurvey administrator)
 -	`-e LIMESURVEY_ADMIN_EMAIL=...` (defaults to "lime@lime.lime" - The email address of the Limesurvey administrator)
+-	`-e LIMESURVEY_SMTP_HOST=...` (defaults to "" - set the SMTP host - you can also specify a different port than 25 by using this format: [hostname:port], e.g. "smtp.example.com:587")
+-	`-e LIMESURVEY_SMTP_USER=...` (defaults to "" - only set this if your server requires authorization - if you set it you HAVE to set a password too)
+-	`-e LIMESURVEY_SMTP_PASSWORD=...` (defaults to "" - SMTP authorization password - empty password is not allowed)
+-	`-e LIMESURVEY_SMTP_SSL=...` (defaults to "" - set this to "ssl" to use SSL/TLS or "tls" to use StartTLS for SMTP connection)
 -	`-e LIMESURVEY_DEBUG=...` (defaults to 0 - Debug level of Limesurvey, 0 is off, 1 for errors, 2 for strict PHP and to be able to edit standard templates)
+-	`-e LIMESURVEY_SMTP_DEBUG=...` (defaults to "" - set this to any value to enable SMTP debug mode)
 -	`-e LIMESURVEY_SQL_DEBUG=...` (defaults to 0 - Debug level of Limesurvey for SQL, 0 is off, 1 is on - note requires LIMESURVEY_DEBUG set to 2)
 -	`-e LIMESURVEY_USE_INNODB=...` (defaults to '' - Leave blank or don't set to use standard MyISAM database. Set to any value to use InnoDB (required for some cloud providers))
 -	`-e LIMESURVEY_USE_DB_SESSIONS=...` (defaults to '' - Leave blank or don't set to use file based sessions. Set to any value to use DB based sessions

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,26 +8,26 @@ cd /var/www/html
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
 #  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 file_env() {
-	local var="$1"
-	local fileVar="${var}_FILE"
-	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
-		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
-		exit 1
-	fi
-	local val="$def"
-	if [ "${!var:-}" ]; then
-		val="${!var}"
-	elif [ "${!fileVar:-}" ]; then
-		val="$(< "${!fileVar}")"
-	fi
-	export "$var"="$val"
-	unset "$fileVar"
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+    export "$var"="$val"
+    unset "$fileVar"
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'LIMESURVEY_DB_HOST' 'mysql'
-	file_env 'LIMESURVEY_TABLE_PREFIX' ''
+    file_env 'LIMESURVEY_DB_HOST' 'mysql'
+    file_env 'LIMESURVEY_TABLE_PREFIX' ''
     file_env 'LIMESURVEY_ADMIN_NAME' 'Lime Administrator'
     file_env 'LIMESURVEY_ADMIN_EMAIL' 'lime@lime.lime'
     file_env 'LIMESURVEY_ADMIN_USER' ''
@@ -39,21 +39,21 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     file_env 'LIMESURVEY_USE_DB_SESSIONS' ''
     file_env 'LIMESURVEY_DONT_SHOW_SCRIPT_NAME' ''
 
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'LIMESURVEY_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$LIMESURVEY_DB_USER" = 'root' ]; then
-		file_env 'LIMESURVEY_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'LIMESURVEY_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'LIMESURVEY_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-limesurvey}"
-	if [ -z "$LIMESURVEY_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required LIMESURVEY_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e LIMESURVEY_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be LIMESURVEY_DB_USER and LIMESURVEY_DB_NAME.)'
-		exit 1
-	fi
+    # if we're linked to MySQL and thus have credentials already, let's use them
+    file_env 'LIMESURVEY_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
+    if [ "$LIMESURVEY_DB_USER" = 'root' ]; then
+        file_env 'LIMESURVEY_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
+    else
+        file_env 'LIMESURVEY_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
+    fi
+    file_env 'LIMESURVEY_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-limesurvey}"
+    if [ -z "$LIMESURVEY_DB_PASSWORD" ]; then
+        echo >&2 'error: missing required LIMESURVEY_DB_PASSWORD environment variable'
+        echo >&2 '  Did you forget to -e LIMESURVEY_DB_PASSWORD=... ?'
+        echo >&2
+        echo >&2 '  (Also of interest might be LIMESURVEY_DB_USER and LIMESURVEY_DB_NAME.)'
+        exit 1
+    fi
 
     echo >&2 "Copying default container default config files into config volume..."
     cp -dpR /var/lime/application/config/* application/config
@@ -72,16 +72,16 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
     if ! [ -e application/config/config.php ]; then
         echo >&2 "No config file in $(pwd) Copying default config file..."
-		#Copy default config file but also allow for the addition of attributes
+        #Copy default config file but also allow for the addition of attributes
 awk '/lime_/ && c == 0 { c = 1; system("cat") } { print }' application/config/config-sample-mysql.php > application/config/config.php <<'EOPHP'
 'attributes' => array(),
 EOPHP
     fi
 
-	# Install BaltimoreCyberTrustRoot.crt.pem if needed
-	if [ "$MYSQL_SSL_CA" == "BaltimoreCyberTrustRoot.crt.pem" ] && ! [ -e BaltimoreCyberTrustRoot.crt.pem ]; then
-		echo "Downloading BaltimoreCyberTrustroot.crt.pem"
-		if curl -o BaltimoreCyberTrustRoot.crt.pem -fsL "https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem"; then
+    # Install BaltimoreCyberTrustRoot.crt.pem if needed
+    if [ "$MYSQL_SSL_CA" == "BaltimoreCyberTrustRoot.crt.pem" ] && ! [ -e BaltimoreCyberTrustRoot.crt.pem ]; then
+        echo "Downloading BaltimoreCyberTrustroot.crt.pem"
+        if curl -o BaltimoreCyberTrustRoot.crt.pem -fsL "https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem"; then
             echo "Downloaded successfully"
         else
             echo "Failed to download certificate - continuing anyway"
@@ -108,7 +108,7 @@ EOPHP
     set_config 'tablePrefix' "'$LIMESURVEY_TABLE_PREFIX'"
     set_config 'username' "'$LIMESURVEY_DB_USER'"
     set_config 'password' "'$LIMESURVEY_DB_PASSWORD'"
-	set_config 'urlFormat' "'path'"
+    set_config 'urlFormat' "'path'"
     set_config 'debug' "$LIMESURVEY_DEBUG"
     set_config 'debugsql' "$LIMESURVEY_SQL_DEBUG"
     set_config 'showScriptName' "true"
@@ -116,8 +116,8 @@ EOPHP
         set_config 'showScriptName' "false"
     fi
 
-	if [ -n "$MYSQL_SSL_CA" ]; then
-		set_config 'attributes' "array(PDO::MYSQL_ATTR_SSL_CA => '\/var\/www\/html\/$MYSQL_SSL_CA', PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false)"
+    if [ -n "$MYSQL_SSL_CA" ]; then
+        set_config 'attributes' "array(PDO::MYSQL_ATTR_SSL_CA => '\/var\/www\/html\/$MYSQL_SSL_CA', PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false)"
     fi
 
     #Remove session line if exists
@@ -131,13 +131,13 @@ EOPHP
     fi
 
 
-	if [ -n "$LIMESURVEY_USE_INNODB" ]; then
+    if [ -n "$LIMESURVEY_USE_INNODB" ]; then
         chmod ug+w application/core/db/MysqlSchema.php
-		#If you want to use INNODB - remove MyISAM specification from LimeSurvey code
-		sed -i "/ENGINE=MyISAM/s/\(ENGINE=MyISAM \)//1" application/core/db/MysqlSchema.php
+        #If you want to use INNODB - remove MyISAM specification from LimeSurvey code
+        sed -i "/ENGINE=MyISAM/s/\(ENGINE=MyISAM \)//1" application/core/db/MysqlSchema.php
         #Also set mysqlEngine in config file
-		sed -i "/\/\/ Update default LimeSurvey config here/s//'mysqlEngine'=>'InnoDB',/" application/config/config.php
-		DBENGINE='InnoDB'
+        sed -i "/\/\/ Update default LimeSurvey config here/s//'mysqlEngine'=>'InnoDB',/" application/config/config.php
+        DBENGINE='InnoDB'
         chmod ug-w application/core/db/MysqlSchema.php
     fi
 
@@ -155,7 +155,7 @@ EOPHP
     chown www-data:www-data -R /var/lime/sessions
     chmod ug=rwx -R /var/lime/sessions
 
-	DBSTATUS=$(TERM=dumb php -- "$LIMESURVEY_DB_HOST" "$LIMESURVEY_DB_USER" "$LIMESURVEY_DB_PASSWORD" "$LIMESURVEY_DB_NAME" "$LIMESURVEY_TABLE_PREFIX" "$MYSQL_SSL_CA" <<'EOPHP'
+    DBSTATUS=$(TERM=dumb php -- "$LIMESURVEY_DB_HOST" "$LIMESURVEY_DB_USER" "$LIMESURVEY_DB_PASSWORD" "$LIMESURVEY_DB_NAME" "$LIMESURVEY_TABLE_PREFIX" "$MYSQL_SSL_CA" <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -211,17 +211,16 @@ EOPHP
 
     if [ "$DBSTATUS" != "DBEXISTS" ] &&  [ -n "$LIMESURVEY_ADMIN_USER" ] && [ -n "$LIMESURVEY_ADMIN_PASSWORD" ]; then
         echo >&2 'Database not yet populated - installing Limesurvey database'
-	    php application/commands/console.php install "$LIMESURVEY_ADMIN_USER" "$LIMESURVEY_ADMIN_PASSWORD" "$LIMESURVEY_ADMIN_NAME" "$LIMESURVEY_ADMIN_EMAIL" verbose
-	fi
+        php application/commands/console.php install "$LIMESURVEY_ADMIN_USER" "$LIMESURVEY_ADMIN_PASSWORD" "$LIMESURVEY_ADMIN_NAME" "$LIMESURVEY_ADMIN_EMAIL" verbose
+    fi
 
-	if [ -n "$LIMESURVEY_ADMIN_USER" ] && [ -n "$LIMESURVEY_ADMIN_PASSWORD" ]; then
-		echo >&2 'Updating password for admin user'
+    if [ -n "$LIMESURVEY_ADMIN_USER" ] && [ -n "$LIMESURVEY_ADMIN_PASSWORD" ]; then
+        echo >&2 'Updating password for admin user'
         php application/commands/console.php resetpassword "$LIMESURVEY_ADMIN_USER" "$LIMESURVEY_ADMIN_PASSWORD"
-	fi
+    fi
 
     #flush asssets (clear cache on restart)
     php application/commands/console.php flushassets
-
 fi
 
 exec "$@"


### PR DESCRIPTION
SMTP settings can now be configured via environment variables (e.g. `LIMESURVEY_SMTP_HOST` and `LIMESURVEY_SMTP_PASSWORD_FILE`).

[x] I have tested my changes in a running container stack and then sending a test mail.
[x] I have added corresponding documentation to the README.

Closes #18 

Besides the feature addition I also fixed some indentations (there were sometimes tabs instead of spaces).