### PR TITLE
reset smtpconfig defaults

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -149,6 +149,14 @@ EOPHP
     fi
 
     #Set SMTP settings if environment contains values for it
+    set_config 'emailmethod' "mail"
+    set_config 'emailsmtphost' "localhost"
+    set_config 'siteadminemail' "your-email@example.net"
+    set_config 'siteadminname' "Your Name"
+    set_config 'emailsmtpuser' ""
+    set_config 'emailsmtppassword' ""
+    set_config 'emailsmtpssl' ""
+    set_config 'emailsmtpdebug' ""
     if [ -n "$LIMESURVEY_SMTP_HOST" ]; then
         set_config 'emailmethod' "'smtp'"
         set_config 'emailsmtphost' "'$LIMESURVEY_SMTP_HOST'"


### PR DESCRIPTION
This PR is meant to make sure that smtp config values are reset in case the environment no longer contains values for it.