### PR TITLE
Postgres support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ENV DOWNLOAD_URL https://download.limesurvey.org/latest-master/limesurvey6.4.0+2
 ENV DOWNLOAD_SHA256 2631c8c03d96e2e5ba3f8c80f9e8488825c3259d6a5b8c1148400d3de4419382
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev libpq-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
-    && docker-php-ext-install gd mysqli pdo pdo_mysql opcache zip iconv tidy \
+    && docker-php-ext-install gd mysqli pdo pdo_mysql pdo_pgsql pgsql opcache zip iconv tidy \
     && docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ENV DOWNLOAD_URL https://download.limesurvey.org/latest-master/limesurvey6.4.0+2
 ENV DOWNLOAD_SHA256 2631c8c03d96e2e5ba3f8c80f9e8488825c3259d6a5b8c1148400d3de4419382
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev libpq-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev libpq-dev libonig-dev libzip-dev && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
-    && docker-php-ext-install gd mysqli pdo pdo_mysql pdo_pgsql pgsql opcache zip iconv tidy \
+    && docker-php-ext-install gd mysqli mbstring pgsql pdo pdo_mysql pdo_pgsql opcache zip iconv tidy \
     && docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DOWNLOAD_URL https://download.limesurvey.org/latest-master/limesurvey6.4.0+2
 ENV DOWNLOAD_SHA256 2631c8c03d96e2e5ba3f8c80f9e8488825c3259d6a5b8c1148400d3de4419382
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev libpq-dev libonig-dev libzip-dev && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y unzip libc-client-dev libfreetype6-dev libmcrypt-dev libpng-dev libjpeg-dev libldap-common libldap2-dev zlib1g-dev libkrb5-dev libtidy-dev libzip-dev libsodium-dev libpq-dev libonig-dev && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype=/usr/include/  --with-jpeg=/usr \
     && docker-php-ext-install gd mysqli mbstring pgsql pdo pdo_mysql pdo_pgsql opcache zip iconv tidy \
     && docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ $ docker run --name some-limesurvey --link some-mysql:mysql -d adamzammit/limesu
 
 The following environment variables are also honored for configuring your Limesurvey instance. If Limesurvey is already installed, these environment variables will update the Limesurvey config file.
 
+-	`-e LIMESURVEY_DB_TYPE=...` (defaults to 'mysql', change to 'pgsql' as needed)
 -	`-e LIMESURVEY_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
+-	`-e LIMESURVEY_DB_PORT=...` (defaults to 3306, _must_ change to e.g. 5432 if a Postgres database is used)
 -	`-e LIMESURVEY_DB_USER=...` (defaults to "root")
 -	`-e LIMESURVEY_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
 -	`-e LIMESURVEY_DB_NAME=...` (defaults to "limesurvey")
@@ -143,4 +145,3 @@ Notes
 -----
 
 This Dockerfile is based on the Dockerfile from the [Wordpress official docker image](https://github.com/docker-library/wordpress/tree/8ab70dd61a996d58c0addf4867a768efe649bf65/php5.6/apache)
-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,9 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+    file_env 'LIMESURVEY_DB_TYPE' 'mysql'
     file_env 'LIMESURVEY_DB_HOST' 'mysql'
+    file_env 'LIMESURVEY_DB_PORT' '3306'
     file_env 'LIMESURVEY_TABLE_PREFIX' ''
     file_env 'LIMESURVEY_ADMIN_NAME' 'Lime Administrator'
     file_env 'LIMESURVEY_ADMIN_EMAIL' 'lime@lime.lime'
@@ -111,7 +113,13 @@ EOPHP
         sed -i "/'$key'/s>\(.*\)>$value,1"  application/config/config.php
     }
 
-    set_config 'connectionString' "'mysql:host=$LIMESURVEY_DB_HOST;port=3306;dbname=$LIMESURVEY_DB_NAME;'"
+    LIMESURVEY_DB_CHARSET="utf8mb4"
+    if [ $LIMESURVEY_DB_TYPE == pgsql ]; then
+        LIMESURVEY_DB_CHARSET="utf8"
+    fi
+
+    set_config 'connectionString' "'$LIMESURVEY_DB_TYPE:host=$LIMESURVEY_DB_HOST;port=$LIMESURVEY_DB_PORT;dbname=$LIMESURVEY_DB_NAME;'"
+    set_config 'charset' "'$LIMESURVEY_DB_CHARSET'"
     set_config 'tablePrefix' "'$LIMESURVEY_TABLE_PREFIX'"
     set_config 'username' "'$LIMESURVEY_DB_USER'"
     set_config 'password' "'$LIMESURVEY_DB_PASSWORD'"
@@ -190,61 +198,13 @@ EOPHP
     chown www-data:www-data -R /var/lime/sessions
     chmod ug=rwx -R /var/lime/sessions
 
-    DBSTATUS=$(TERM=dumb php -- "$LIMESURVEY_DB_HOST" "$LIMESURVEY_DB_USER" "$LIMESURVEY_DB_PASSWORD" "$LIMESURVEY_DB_NAME" "$LIMESURVEY_TABLE_PREFIX" "$MYSQL_SSL_CA" <<'EOPHP'
-<?php
-// database might not exist, so let's try creating it (just to be safe)
 
-error_reporting(E_ERROR | E_PARSE);
-mysqli_report(MYSQLI_REPORT_OFF);
+    # The following 4 lines are borrowed from martialblog's entrypoint.sh
+    # Check if LimeSurvey database is provisioned
+    echo 'Info: Check if database already provisioned. Nevermind the stack trace.'
+    php application/commands/console.php updatedb || MUST_CREATE_DB=true
 
-$stderr = fopen('php://stderr', 'w');
-$host = $argv[1];
-$socket = null;
-if (str_contains($host, ':')) {
-    list($host, $socket) = explode(':', $argv[1], 2);
-}
-$port = 0;
-if (is_numeric($socket)) {
-    $port = (int) $socket;
-    $socket = null;
-}
-
-do {
-    $con = mysqli_init();
-    if (isset($argv[6]) && !empty($argv[6])) {
-	    mysqli_ssl_set($con,NULL,NULL,"/var/www/html/" . $argv[6],NULL,NULL);
-    }
-    $mysql = mysqli_real_connect($con,$host, $argv[2], $argv[3], '', $port, $socket, MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT);
-        if (!$mysql) {
-                fwrite($stderr, "MySQL Connection Error will retry in 3 seconds...\n");
-                sleep(3);
-        }
-} while (!$mysql);
-
-if (!$con->query('CREATE DATABASE IF NOT EXISTS `' . $con->real_escape_string($argv[4]) . '`')) {
-        fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $con->error . "\n");
-        $con->close();
-        exit(1);
-}
-
-$stat = $con->select_db($con->real_escape_string($argv[4]));
-
-$inst = $con->query("SHOW TABLES LIKE '" . $con->real_escape_string($argv[5]) . "users'");
-
-$nrows = $inst->num_rows;
-
-$con->close();
-
-if ($nrows > 0) {
-        exit("DBEXISTS");
-} else {
-        exit(0);
-}
-
-EOPHP
-)
-
-    if [ "$DBSTATUS" != "DBEXISTS" ] &&  [ -n "$LIMESURVEY_ADMIN_USER" ] && [ -n "$LIMESURVEY_ADMIN_PASSWORD" ]; then
+    if [ -v MUST_CREATE_DB ] && [ -n "$LIMESURVEY_ADMIN_USER" ] && [ -n "$LIMESURVEY_ADMIN_PASSWORD" ]; then
         echo >&2 'Database not yet populated - installing Limesurvey database'
         php application/commands/console.php install "$LIMESURVEY_ADMIN_USER" "$LIMESURVEY_ADMIN_PASSWORD" "$LIMESURVEY_ADMIN_NAME" "$LIMESURVEY_ADMIN_EMAIL" verbose
     fi


### PR DESCRIPTION
Adds support for Postgres databases to the container.

Addresses #20.

Two additional environment variables are introduced:

- `LIMESURVEY_DB_TYPE` which can be set to "pgsql"
- `LIMESURVEY_DB_PORT` which must be set to the appropriate port (e.g., 5432) if a Postgres database is used